### PR TITLE
Include a growth advantage inclusion threshold

### DIFF
--- a/config/mlr/h1n1pdm.yaml
+++ b/config/mlr/h1n1pdm.yaml
@@ -17,6 +17,7 @@ model:
   pool_scale: 0.25 # between 0.1 to 0.5
   generation_time: 0.19 # 2.7 days from from Lessler et al. 2011 (https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2937282/). Divide generation time in days by the number of days in the aggregation frequency above for proper GA calculations.
   pivot: "C.1.9.3"
+  location_ga_inclusion_threshold: 10
   hierarchical: true # Keep hierarchical for analysis across regions
   version: "MLR"
 

--- a/config/mlr/h3n2.yaml
+++ b/config/mlr/h3n2.yaml
@@ -17,6 +17,7 @@ model:
   pool_scale: 0.25 # between 0.1 to 0.5
   generation_time: 0.22 # range: 3.1 days with range of 2.2–4.0 days (Carrat et al., 2008 https://academic.oup.com/aje/article/167/7/775/83777). Divide this number of days by the number of days in the aggregation interval above for proper GA calculation.
   pivot: "J.2.2"
+  location_ga_inclusion_threshold: 10
   hierarchical: true # Keep hierarchical for analysis across regions
   version: "MLR"
 

--- a/config/mlr/vic.yaml
+++ b/config/mlr/vic.yaml
@@ -17,6 +17,7 @@ model:
   pool_scale: 0.25 # between 0.1 to 0.5
   generation_time: 0.24 # 3.4 days from Carrat et al. 2008 (https://academic.oup.com/aje/article/167/7/775/83777). Divide generation time in days by the number of days in the aggregation frequency above for proper GA calculations.
   pivot: "C.5"
+  location_ga_inclusion_threshold: 10
   hierarchical: true # Keep hierarchical for analysis across regions
   version: "MLR"
 

--- a/scripts/run-model.py
+++ b/scripts/run-model.py
@@ -329,7 +329,7 @@ def make_raw_freq_tidy(data, location):
     return {"metadata": metadata, "data": entries}
 
 # export results MLR model (with GA)
-def export_results_mlr(multi_posterior, ps, path, data_name, hier):
+def export_results_mlr(multi_posterior, ps, path, data_name, hier, ga_inclusion_threshold, variant_location_counts):
     EXPORT_SITES = ["freq", "ga", "freq_forecast"]
     EXPORT_DATED = [True, False, True]
     EXPORT_FORECASTS = [False, False, True]
@@ -383,17 +383,33 @@ def export_results_mlr(multi_posterior, ps, path, data_name, hier):
                 )
             )
         else:
-            results.append(
-                ef.posterior.get_sites_variants_tidy(
-                    posterior.samples,
-                    posterior.data,
-                    EXPORT_SITES,
-                    EXPORT_DATED,
-                    EXPORT_FORECASTS,
-                    ps,
-                    location,
-                )
+            site_variants_data = ef.posterior.get_sites_variants_tidy(
+                posterior.samples,
+                posterior.data,
+                EXPORT_SITES,
+                EXPORT_DATED,
+                EXPORT_FORECASTS,
+                ps,
+                location,
             )
+
+            # Apply filtering on ga values
+            filtered_data = []
+            for entry in site_variants_data["data"]:
+                if entry["site"] == "ga":
+                    variant = entry["variant"]
+
+                    # Lookup the total sequence count for this (location, variant)
+                    variant_count = variant_location_counts.get((location, variant), 0)
+
+                    # print(f"Location: {location}, Variant: {variant}, Count: {variant_count}")
+
+                    if variant_count < ga_inclusion_threshold:
+                        continue  # Skip this entry
+                filtered_data.append(entry)
+
+            site_variants_data["data"] = filtered_data
+            results.append(site_variants_data)
 
     # Add raw frequencies
     for location, posterior in multi_posterior.locator.items():
@@ -477,6 +493,16 @@ def export_results_latent(multi_posterior, ps, path, data_name, hier):
     results["metadata"]["updated"] = pd.to_datetime(date.today())
     ef.save_json(results, path=f"{path}/{data_name}_results.json")
 
+def nonnegative_int(value):
+    """
+    Custom argparse type function to verify only
+    positive integers are provided as arguments
+    """
+    int_value = int(value)
+    if int_value <= 0:
+        raise argparse.ArgumentTypeError(f"{int_value} is not a positive integer.")
+    return int_value
+
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
@@ -511,14 +537,27 @@ if __name__ == "__main__":
         "--max-date",
         help="Latest date in ISO 8601 format (YYYY-MM-DD) or backward-looking relative date in ISO 8601 duration (e.g., '14D' or 'P14D') for observed frequency estimation. Any aggregation frequency operates backward in time from this date. If this date isn't provided, the latest date from the given sequence counts data will be used.",
     )
+
+    parser.add_argument(
+        "--location-ga-inclusion-threshold", type=nonnegative_int, default=0,
+        help="Mininum number of sequences that need to be observed for a specific "
+        + "location x variant combination. Default is 0, ie including all combinations "
+        + "even if there isn't data for a particular combination."
+    )
+
     args = parser.parse_args()
 
     # Load configuration, data, and create model
     config = ModelConfig(args.config)
     print(f"Config loaded: {config.path}")
 
+    # Load sequence data for evofr
     raw_seq, locations = config.load_data(args.seq_path)
     print("Data loaded sucessfuly")
+
+    # Calculate variant x location sequence counts
+    variant_location_counts = raw_seq.groupby(["location", "variant"])["sequences"].sum().to_dict()
+    print("variant_location_counts:", variant_location_counts)
 
     override_hier = None
     if args.hier:
@@ -547,6 +586,14 @@ if __name__ == "__main__":
     if args.pivot and args.pivot != "None":
         pivot = args.pivot
     print("pivot", pivot)
+
+    # Load location_ga_inclusion_threshold
+    location_ga_inclusion_threshold = None
+    if config.config["model"]["location_ga_inclusion_threshold"]:
+        location_ga_inclusion_threshold = config.config["model"]["location_ga_inclusion_threshold"]
+    if args.location_ga_inclusion_threshold and args.location_ga_inclusion_threshold != "None":
+        location_ga_inclusion_threshold = args.location_ga_inclusion_threshold
+    print("location_ga_inclusion_threshold", location_ga_inclusion_threshold)
 
     # Find aggregation_frequency
     aggregation_frequency = None
@@ -588,6 +635,6 @@ if __name__ == "__main__":
         )
         data_name = args.data_name or config.config["data"]["name"]
         if config.config["model"]["version"] == "MLR":
-            export_results_mlr(multi_posterior, ps, export_path, data_name, hier)
+            export_results_mlr(multi_posterior, ps, export_path, data_name, hier, location_ga_inclusion_threshold, variant_location_counts)
         elif config.config["model"]["version"] == "Latent":
             export_results_latent(multi_posterior, ps, export_path, data_name, hier)


### PR DESCRIPTION
Due to the workings of the hierarchical model, locations that either completely lack data for a particular variant or mostly lack data for a particular variant will still get growth advantages estimates included. These largely recapitulate the hierarchical prior. This commit drops growth advantages for particular location x variant combinations that lack data.

This was largely copied from the previous forecasts-ncov version here: https://github.com/nextstrain/forecasts-ncov/pull/129. The only major difference is that in this current PR I imported `location_ga_inclusion_threshold` via `config/mlr/h3n2.yaml` as this version tends to not use command line arguments and instead uses the config. I do prefer the command line argument version in forecasts-ncov, but thought better to have consistency with the rest of the repo.
