### PR TITLE
Move from biweekly aggregation to weekly aggregation

### DIFF
--- a/config/mlr/h1n1pdm.yaml
+++ b/config/mlr/h1n1pdm.yaml
@@ -3,7 +3,7 @@ data:
   name: "MLR" # Model version
   case_path: "data/test/prepared_cases.tsv"
   seq_path: "results/h1n1pdm_2024-02/variant_seq_counts_subyr_subloc.tsv"
-  aggregation_frequency: "14D"
+  aggregation_frequency: "7D"
 
 settings:
   fit: true # Fit the model?

--- a/config/mlr/h1n1pdm.yaml
+++ b/config/mlr/h1n1pdm.yaml
@@ -13,9 +13,9 @@ settings:
   ps: [0.5, 0.8, 0.95] # HPDI intervals to be exported
 
 model:
-  forecast_L: 26
+  forecast_L: 52
   pool_scale: 0.25 # between 0.1 to 0.5
-  generation_time: 0.19 # 2.7 days from from Lessler et al. 2011 (https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2937282/). Divide generation time in days by the number of days in the aggregation frequency above for proper GA calculations.
+  generation_time: 0.39 # 2.7 days from from Lessler et al. 2011 (https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2937282/). Divide generation time in days by the number of days in the aggregation frequency above for proper GA calculations.
   pivot: "C.1.9.3"
   location_ga_inclusion_threshold: 10
   hierarchical: true # Keep hierarchical for analysis across regions

--- a/config/mlr/h3n2.yaml
+++ b/config/mlr/h3n2.yaml
@@ -13,9 +13,9 @@ settings:
   ps: [0.5, 0.8, 0.95] # HPDI intervals to be exported
 
 model:
-  forecast_L: 26
+  forecast_L: 52
   pool_scale: 0.25 # between 0.1 to 0.5
-  generation_time: 0.22 # range: 3.1 days with range of 2.2–4.0 days (Carrat et al., 2008 https://academic.oup.com/aje/article/167/7/775/83777). Divide this number of days by the number of days in the aggregation interval above for proper GA calculation.
+  generation_time: 0.44 # range: 3.1 days with range of 2.2–4.0 days (Carrat et al., 2008 https://academic.oup.com/aje/article/167/7/775/83777). Divide this number of days by the number of days in the aggregation interval above for proper GA calculation.
   pivot: "J.2.2"
   location_ga_inclusion_threshold: 10
   hierarchical: true # Keep hierarchical for analysis across regions

--- a/config/mlr/h3n2.yaml
+++ b/config/mlr/h3n2.yaml
@@ -3,7 +3,7 @@ data:
   name: "MLR" # Model name
   case_path: "data/test/prepared_cases.tsv"
   seq_path: "results/h3n2_2024-02/variant_seq_counts_subyr_subloc.tsv"
-  aggregation_frequency: "14D"
+  aggregation_frequency: "7D"
 
 settings:
   fit: true # Fit the model?

--- a/config/mlr/vic.yaml
+++ b/config/mlr/vic.yaml
@@ -3,7 +3,7 @@ data:
   name: "MLR" # Model version
   case_path: "data/test/prepared_cases.tsv"
   seq_path: "results/vic_2024-02/variant_seq_counts_subyr_subloc.tsv"
-  aggregation_frequency: "14D"
+  aggregation_frequency: "7D"
 
 settings:
   fit: true # Fit the model?

--- a/config/mlr/vic.yaml
+++ b/config/mlr/vic.yaml
@@ -13,9 +13,9 @@ settings:
   ps: [0.5, 0.8, 0.95] # HPDI intervals to be exported
 
 model:
-  forecast_L: 26
+  forecast_L: 52
   pool_scale: 0.25 # between 0.1 to 0.5
-  generation_time: 0.24 # 3.4 days from Carrat et al. 2008 (https://academic.oup.com/aje/article/167/7/775/83777). Divide generation time in days by the number of days in the aggregation frequency above for proper GA calculations.
+  generation_time: 0.49 # 3.4 days from Carrat et al. 2008 (https://academic.oup.com/aje/article/167/7/775/83777). Divide generation time in days by the number of days in the aggregation frequency above for proper GA calculations.
   pivot: "C.5"
   location_ga_inclusion_threshold: 10
   hierarchical: true # Keep hierarchical for analysis across regions


### PR DESCRIPTION
The MLR observation model should be fully equivalent whether we bin sequence count observations daily, weekly or biweekly. However, I prefer weekly as it:
- feels more natural
- gives more empirical dots to compare to even if each dot is a bit noisier
- helps with fast growing things like 158D/160K
