### PR TITLE
Fallback to original URL format for older models

### DIFF
--- a/viz/src/main.jsx
+++ b/viz/src/main.jsx
@@ -72,6 +72,12 @@ function modelUrl(variantClassification, subtypeResolution, modelDate) {
   let url = `https://data.nextstrain.org/files/workflows/forecasts-flu/gisaid/${variantClassification}/${subtypeResolution}/mlr/MLR_results.json`;
 
   if (modelDate) {
+    // Fall back to the original URL format for model results generated prior to
+    // our support for multiple data provenances and variant classifications.
+    if (Date.parse(modelDate) < Date.parse("2025-12-23")) {
+      url = `https://data.nextstrain.org/files/workflows/forecasts-flu/${subtypeResolution}/mlr/MLR_results.json`;
+    }
+
     url = url.replace(/([^/]+)$/, `${modelDate}_MLR_results.json`);
   }
 


### PR DESCRIPTION
## Description of proposed changes

Fixes a bug caused by the recent switch to the URL format for our model JSONs where model JSONs generated prior to that switch could not be loaded. The new URL format includes data provenance and variant classification details that were not present in the original URL format. This commit fixes the issue by falling back to the original URL format when the requested model date occurred prior to the switch in URL formats.

This implementation is not ideal in that it hardcodes a specific date and it doesn't hide the new amino acid haplotypes visualization components for older models which gives the impression that we've always had those components. A better implementation would 1) allow us to pass multiple URLs to the model fetching logic which would internally fallback from the first option to subsequent options and 2) hide the amino acid haplotype components when models couldn't be loaded for them.


## Related issue(s)

Closes #27

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
