### PR TITLE
Collapse low-count haplotype counts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ This changelog is intended for _humans_ and follows many of the principles from 
 Changes for this project _do not_ currently follow the [Semantic Versioning rules](https://semver.org/spec/v2.0.0.html).
 Instead, changes appear below grouped by the date they were added to the workflow.
 
+# 13 January 2025
+
+ - Collapse low-count haplotype counts into their parental clades instead of the "other" group. See [#30](https://github.com/nextstrain/forecasts-flu/pull/30) for details.
+ - Fix access to dated model results produced before we added support for amino acid haplotypes. See [#28](https://github.com/nextstrain/forecasts-flu/pull/28) for details.
+
 # 23 December 2025
 
  - Add frequency and fitness estimates for amino acid haplotypes for each subtype and geographic resolution. See [#26](https://github.com/nextstrain/forecasts-flu/pull/26) for details.

--- a/Snakefile
+++ b/Snakefile
@@ -154,10 +154,25 @@ rule clade_seq_counts:
             --output {output.sequence_counts}
             """
 
+rule collapse_haplotype_counts:
+    input:
+        sequence_counts = "results/{data_provenance}/{variant_classification}/{lineage}/{geo_resolution}/seq_counts.tsv"
+    output:
+        sequence_counts = "results/{data_provenance}/{variant_classification}/{lineage}/{geo_resolution}/collapsed_seq_counts.tsv"
+    params:
+        haplotype_min_seq=lambda wildcards: config["prepare_data"][wildcards.data_provenance][wildcards.variant_classification][wildcards.geo_resolution]["clade_min_seq"],
+    shell:
+        """
+        python ./scripts/collapse_haplotype_counts.py \
+            --seq-counts {input.sequence_counts} \
+            --haplotype-min-seq {params.haplotype_min_seq} \
+            --output-seq-counts {output.sequence_counts}
+        """
+
 rule prepare_clade_data:
     """Preparing clade counts for analysis"""
     input:
-        sequence_counts = "results/{data_provenance}/{variant_classification}/{lineage}/{geo_resolution}/seq_counts.tsv"
+        sequence_counts = "results/{data_provenance}/{variant_classification}/{lineage}/{geo_resolution}/collapsed_seq_counts.tsv"
     output:
         sequence_counts = "results/{data_provenance}/{variant_classification}/{lineage}/{geo_resolution}/prepared_seq_counts.tsv"
     params:

--- a/scripts/collapse_haplotype_counts.py
+++ b/scripts/collapse_haplotype_counts.py
@@ -1,0 +1,89 @@
+"""Collapse low-count haplotype counts into parent clades."""
+import argparse
+import pandas as pd
+
+
+def positive_int(value):
+    """
+    Custom argparse type function to verify only
+    positive integers are provided as arguments
+    """
+    int_value = int(value)
+    if int_value <= 0:
+        print(f"ERROR: {int_value} is not a positive integer.", file=sys.stderr)
+        sys.exit(1)
+    return int_value
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        __doc__,
+        formatter_class=argparse.RawTextHelpFormatter
+    )
+
+    parser.add_argument(
+        "--seq-counts",
+        metavar="TSV",
+        required=True,
+        help="Path to clade counts TSV with columns: 'location','clade','date','sequences'"
+    )
+
+    parser.add_argument(
+        "--haplotype-min-seq",
+        type=positive_int,
+        help=(
+            "The minimum number of sequences a haplotype must have "
+            "to be included as its own variant. Derived haplotypes below this threshold are collapsed "
+            "into their parental clade. For example, a low-count haplotype 'K:S145N' would be collapsed "
+            "into a haplotype 'K'."
+        )
+    )
+
+    parser.add_argument(
+        "--output-seq-counts",
+        required=True,
+        help="Path to output TSV file for the prepared variants data."
+    )
+
+    args = parser.parse_args()
+
+    seq_counts = pd.read_csv(
+        args.seq_counts,
+        sep='\t',
+    )
+
+    seqs_per_haplotype = seq_counts.groupby(['clade'], as_index=False).aggregate(
+        sequence_count=("sequences", "sum")
+    )
+
+    low_count_haplotypes = set(
+        seqs_per_haplotype.loc[
+            (
+                (seqs_per_haplotype["clade"].str.contains(":")) &
+                (seqs_per_haplotype["sequence_count"] < args.haplotype_min_seq)
+            ),
+            "clade"
+        ].values
+    )
+    seq_counts_with_low_count_haplotypes = seq_counts["clade"].isin(low_count_haplotypes)
+    seq_counts.loc[seq_counts_with_low_count_haplotypes, "clade"] = seq_counts.loc[
+        seq_counts_with_low_count_haplotypes,
+        "clade"
+    ].apply(
+        lambda haplotype: haplotype.split(":")[0]
+    )
+
+    seq_counts = seq_counts.groupby(
+        [
+            'location',
+            'clade',
+            'date',
+        ],
+        as_index=False,
+    ).sum(numeric_only=False)
+
+    seq_counts.to_csv(
+        args.output_seq_counts,
+        sep='\t',
+        index=False,
+    )


### PR DESCRIPTION
## Description of proposed changes

Adds a custom preprocessing rule and script between the generic sequence counts step and the "prepare data" step to collapse low-count haplotypes into their parental clades.

<!-- What is the goal of this pull request? What does this pull request change? -->

## Related issue(s)

Closes #29

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Confirm that collapsed haplotypes address issue with inflated "other" group in [Vic regional frequencies](https://nextstrain.github.io/forecasts-flu/?tab=vic%2Fregion&date=2026-01-13)
- [x] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
